### PR TITLE
More idiomatic unveil

### DIFF
--- a/src/persist.c
+++ b/src/persist.c
@@ -214,8 +214,9 @@ persist(int argc, char *argv[])
 	}
 	free(dpath);
 
-	if (unveil(path, "wc") == -1 || unveil(NULL, NULL) == -1)
+	if (unveil(path, "wc") == -1)
 		FATAL("unveil");
+
 	if (pledge("stdio wpath cpath fattr sendfd", NULL) == -1)
 		FATAL("pledge");
 

--- a/src/sockpipe.c
+++ b/src/sockpipe.c
@@ -38,11 +38,12 @@ sockpipe(const char *path, int verbose)
 	    errx(1, "internal error"));
 	ssa_un.sun_family = AF_UNIX;
 
-	if (pledge("stdio unix unveil", NULL) == -1)
-		ERR("pledge");
 
-	if (unveil(ssa_un.sun_path, "r") == -1 || unveil(NULL, NULL) == -1)
+	if (unveil(ssa_un.sun_path, "r") == -1)
 		ERR("unveil");
+
+	if (pledge("stdio unix", NULL) == -1)
+		ERR("pledge");
 
 	if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
 		ERR("socket");

--- a/src/tinypfctl.c
+++ b/src/tinypfctl.c
@@ -313,7 +313,9 @@ tinypfctl(int argc, char *argv[])
 	log_init(argv[1], debug, verbose);
 	setproctitle("%s", __func__);
 
-	if (unveil(PF_DEVICE, "rw") == -1 || unveil(NULL, NULL) == -1)
+	if (unveil(PF_DEVICE, "rw") == -1)
+		FATAL("unveil");
+	if (unveil(NULL, NULL) == -1)
 		FATAL("unveil");
 
 	ETOI(ctrlfd, ENV_CTRLFD);


### PR DESCRIPTION
The use of OR in a conditional to close further unveil calls is not something I've seen in the base system of OpenBSD, this changes the calls to look more conventional. Additionally this may help debugging if one has to determine which unveil call failed.

In `src/persist.c` calling `unveil(NULL, NULL)` is unnecessary as a pledge is made immediately after without the unveil promise.

In `src/sockpipe.c` I have swapped the ordering of calls to pledge and unveil and removed the unveil pledge to achieve the same effect. Though this does represent a change of behavior in that should a call to unveil be made after this point it is now a fatal error as it is a pledge violation.

In `src/tinypfctl.c` has just been split into two distinct calls to unveil.